### PR TITLE
feat(dependencies): Switch to click-aliases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ requirements = [
     'storyscript==0.23.9',
     'asyncy-hub==0.0.1',
     'click==7.0',
-    'click-alias==0.1.1a2',
+    'click-aliases==1.0.1',
 ]
 
 setup(name=name,

--- a/sls/cli.py
+++ b/sls/cli.py
@@ -2,7 +2,7 @@ import json
 
 import click
 
-from click_alias import ClickAliasedGroup
+from click_aliases import ClickAliasedGroup
 
 
 from .app import App


### PR DESCRIPTION
click-alias is an unmaintained fork of click-aliases;
the latter is maintained by the click team, and
recently updated to support Click 7.