### PR TITLE
Introduce as_suffix for when and service blocks

### DIFF
--- a/sls/completion/ast.py
+++ b/sls/completion/ast.py
@@ -1,3 +1,4 @@
+from sls.completion.items.item import SortGroup
 from sls.completion.items.keyword import KeywordCompletionSymbol
 
 from sls.logging import logger
@@ -308,6 +309,9 @@ class ASTAnalyzer:
             # use of 'as' inside parenthesis is definitely invalid
             return
 
+        as_keyword = KeywordCompletionSymbol(
+            "as", sort_group=SortGroup.ContextKeyword
+        )
         suffixes = ["service_op", "service_suffix"]
 
         try:
@@ -319,7 +323,7 @@ class ASTAnalyzer:
         except Exception:
             # attempt to parse service_block failed - must be a when_block or
             # similar
-            yield KeywordCompletionSymbol("as")
+            yield as_keyword
             return
 
         action = self.service_handler.action(service_name, service_command)
@@ -329,7 +333,7 @@ class ASTAnalyzer:
         # only yield 'as' iff the service can start an event block (=it has
         # events)
         if len(action.events()) > 0:
-            yield KeywordCompletionSymbol("as")
+            yield as_keyword
 
     def get_names(self):
         """

--- a/sls/completion/items/item.py
+++ b/sls/completion/items/item.py
@@ -15,7 +15,8 @@ class SortGroup:
     Action = 20
     Event = 20
     Service = 40
-    Keyword = 70
+    ContextKeyword = 70
+    Keyword = 90
 
 
 class CompletionItem:

--- a/sls/completion/service.py
+++ b/sls/completion/service.py
@@ -21,19 +21,20 @@ class ServiceCompletion:
     def __init__(self, service_handler):
         self.service_handler = service_handler
 
-    def process_suffix(self, stack, tokens, value_stack_name):
+    def process_suffix(self, stack, value_stack_name, in_assignment):
         """
         Extract a service_suffix (=service_name) and yield its actions.
         """
         name = Stack.extract(stack, value_stack_name)[0].value
-        in_assignment = any(tok.text() == "=" for tok in tokens)
         yield from self._service_actions(name, in_assignment=in_assignment)
 
-    def process_when_name(self, stack, tokens):
+    def process_when_name(self, stack):
         """
         Extract a service_suffix (=service_name) after WHEN and yield its actions.
         """
-        commands = self.process_suffix(stack, tokens, "when_service_name")
+        commands = self.process_suffix(
+            stack, "when_service_name", in_assignment=False
+        )
         for command in commands:
             if isinstance(command, Action):
                 # only show commands with events inside when
@@ -79,7 +80,9 @@ class ServiceCompletion:
         """
         Extract previous tokens for service argument completion.
         """
-        actions = self.process_suffix(stack, [], value_stack_name)
+        actions = self.process_suffix(
+            stack, value_stack_name, in_assignment=False
+        )
         service_command = Stack.extract(stack, command_name)[0].value
         yield from Utils.action_args(actions, service_command)
 

--- a/sls/parser/parso.py
+++ b/sls/parser/parso.py
@@ -18,7 +18,7 @@ block: if_block | foreach_block | while_block | when_block | try_block | fn_bloc
 
 
 if_block: 'if' expression NL indented_blocks ('else if' NL indented_blocks)* ['else' NL indented_blocks]
-foreach_block: 'foreach' expression 'as' NAME NL blocks
+foreach_block: 'foreach' expression as_suffix NL blocks
 while_block: 'while' expression NL blocks
 when_block: 'when' when_expression NL blocks
 try_block: 'try' expression NL indented_blocks ['catch' NL indented_blocks]
@@ -47,7 +47,7 @@ mut_arg_name: NAME
 
 atom: value | LPARENS expression RPARENS
 
-value: NAME [ fn_suffix | service_suffix | path_suffix ] | NUMBER | STRING | boolean | NULL | list | map
+value: NAME [ fn_suffix | service_suffix [as_suffix] | path_suffix ] | NUMBER | STRING | boolean | NULL | list | map
 # | REGEX | TIME
 fn_suffix: LPARENS arglist RPARENS
 service_suffix: service_op [arglist]
@@ -69,11 +69,13 @@ map_type: 'Map' '[' type ',' type ']'
 list_type: 'List' '[' type ']'
 
 when_expression: when_service_name when_action
-when_action: NAME when_action_name when_action_suffix
-when_action_suffix: COLON expression when_arglist | when_arglist
+when_action: NAME (when_action_name (when_action_suffix | as_suffix) | as_suffix)
+when_action_suffix: (COLON expression when_arglist | when_arglist)  [as_suffix]
 when_action_name: NAME
 when_service_name: NAME
 when_arglist: (arg_name COLON expression)*
+
+as_suffix: AS NAME
 
 to_tok: 'to'
 # for simplicity assignments are treated as binary operations
@@ -157,6 +159,7 @@ class Parser:
         """
         Feed tokens into parser and return the parser stack.
         """
+        tokens = [*tokens]
         p = BaseParser(self._grammar._pgen_grammar, error_recovery=True)
         tokens = self.with_special_tok(tokens)
         try:

--- a/sls/parser/token.py
+++ b/sls/parser/token.py
@@ -25,6 +25,7 @@ class StoryTokenSpace:
     RPARENS = TokenType("RPARENS")
     COLON = TokenType("COLON")
     DOT = TokenType("DOT")
+    AS = TokenType("AS")
 
     OTHER = TokenType("OTHER", True)
 
@@ -81,6 +82,8 @@ class Token:
             ty = StoryTokenSpace.COLON
         elif id_ == "dot":
             ty = StoryTokenSpace.DOT
+        elif id_ == "as_operator":
+            ty = StoryTokenSpace.AS
         else:
             ty = StoryTokenSpace.OTHER
             # assert 0, id_

--- a/tests/e2e/a_equals.json
+++ b/tests/e2e/a_equals.json
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "false",
-    "sortText": "70-false",
+    "sortText": "90-false",
     "textEdit": {
       "newText": "false ",
       "range": {
@@ -119,7 +119,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "not",
-    "sortText": "70-not",
+    "sortText": "90-not",
     "textEdit": {
       "newText": "not ",
       "range": {
@@ -140,7 +140,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "null",
-    "sortText": "70-null",
+    "sortText": "90-null",
     "textEdit": {
       "newText": "null ",
       "range": {
@@ -353,7 +353,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "true",
-    "sortText": "70-true",
+    "sortText": "90-true",
     "textEdit": {
       "newText": "true ",
       "range": {

--- a/tests/e2e/a_equals_http.json
+++ b/tests/e2e/a_equals_http.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/break.json
+++ b/tests/e2e/break.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "break",
-    "sortText": "70-break",
+    "sortText": "90-break",
     "textEdit": {
       "newText": "break ",
       "range": {

--- a/tests/e2e/break_in_block.json
+++ b/tests/e2e/break_in_block.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "break",
-    "sortText": "70-break",
+    "sortText": "90-break",
     "textEdit": {
       "newText": "break ",
       "range": {

--- a/tests/e2e/builtin_insert_text_middle.json
+++ b/tests/e2e/builtin_insert_text_middle.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/continue.json
+++ b/tests/e2e/continue.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "continue",
-    "sortText": "70-continue",
+    "sortText": "90-continue",
     "textEdit": {
       "newText": "continue ",
       "range": {

--- a/tests/e2e/continue_in_block.json
+++ b/tests/e2e/continue_in_block.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "continue",
-    "sortText": "70-continue",
+    "sortText": "90-continue",
     "textEdit": {
       "newText": "continue ",
       "range": {

--- a/tests/e2e/empty.json
+++ b/tests/e2e/empty.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "break",
-    "sortText": "70-break",
+    "sortText": "90-break",
     "textEdit": {
       "newText": "break ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "continue",
-    "sortText": "70-continue",
+    "sortText": "90-continue",
     "textEdit": {
       "newText": "continue ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "false",
-    "sortText": "70-false",
+    "sortText": "90-false",
     "textEdit": {
       "newText": "false ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "foreach",
-    "sortText": "70-foreach",
+    "sortText": "90-foreach",
     "textEdit": {
       "newText": "foreach ",
       "range": {
@@ -89,7 +89,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "function",
-    "sortText": "70-function",
+    "sortText": "90-function",
     "textEdit": {
       "newText": "function ",
       "range": {
@@ -134,7 +134,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "if",
-    "sortText": "70-if",
+    "sortText": "90-if",
     "textEdit": {
       "newText": "if ",
       "range": {
@@ -203,7 +203,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "not",
-    "sortText": "70-not",
+    "sortText": "90-not",
     "textEdit": {
       "newText": "not ",
       "range": {
@@ -224,7 +224,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "null",
-    "sortText": "70-null",
+    "sortText": "90-null",
     "textEdit": {
       "newText": "null ",
       "range": {
@@ -389,7 +389,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "return",
-    "sortText": "70-return",
+    "sortText": "90-return",
     "textEdit": {
       "newText": "return ",
       "range": {
@@ -458,7 +458,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "throw",
-    "sortText": "70-throw",
+    "sortText": "90-throw",
     "textEdit": {
       "newText": "throw ",
       "range": {
@@ -479,7 +479,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "true",
-    "sortText": "70-true",
+    "sortText": "90-true",
     "textEdit": {
       "newText": "true ",
       "range": {
@@ -500,7 +500,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "try",
-    "sortText": "70-try",
+    "sortText": "90-try",
     "textEdit": {
       "newText": "try ",
       "range": {
@@ -545,7 +545,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "when",
-    "sortText": "70-when",
+    "sortText": "90-when",
     "textEdit": {
       "newText": "when ",
       "range": {
@@ -566,7 +566,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "while",
-    "sortText": "70-while",
+    "sortText": "90-while",
     "textEdit": {
       "newText": "while ",
       "range": {

--- a/tests/e2e/expr_complete.json
+++ b/tests/e2e/expr_complete.json
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "false",
-    "sortText": "70-false",
+    "sortText": "90-false",
     "textEdit": {
       "newText": "false ",
       "range": {
@@ -119,7 +119,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "not",
-    "sortText": "70-not",
+    "sortText": "90-not",
     "textEdit": {
       "newText": "not ",
       "range": {
@@ -140,7 +140,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "null",
-    "sortText": "70-null",
+    "sortText": "90-null",
     "textEdit": {
       "newText": "null ",
       "range": {
@@ -353,7 +353,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "true",
-    "sortText": "70-true",
+    "sortText": "90-true",
     "textEdit": {
       "newText": "true ",
       "range": {

--- a/tests/e2e/fn_arg_first_value.json
+++ b/tests/e2e/fn_arg_first_value.json
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "false",
-    "sortText": "70-false",
+    "sortText": "90-false",
     "textEdit": {
       "newText": "false ",
       "range": {
@@ -140,7 +140,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "not",
-    "sortText": "70-not",
+    "sortText": "90-not",
     "textEdit": {
       "newText": "not ",
       "range": {
@@ -161,7 +161,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "null",
-    "sortText": "70-null",
+    "sortText": "90-null",
     "textEdit": {
       "newText": "null ",
       "range": {
@@ -374,7 +374,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "true",
-    "sortText": "70-true",
+    "sortText": "90-true",
     "textEdit": {
       "newText": "true ",
       "range": {

--- a/tests/e2e/fn_arg_second.json
+++ b/tests/e2e/fn_arg_second.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/foreach.json
+++ b/tests/e2e/foreach.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "foreach",
-    "sortText": "70-foreach",
+    "sortText": "90-foreach",
     "textEdit": {
       "newText": "foreach ",
       "range": {

--- a/tests/e2e/func.json
+++ b/tests/e2e/func.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "function",
-    "sortText": "70-function",
+    "sortText": "90-function",
     "textEdit": {
       "newText": "function ",
       "range": {

--- a/tests/e2e/funcdecl_arg_name.json
+++ b/tests/e2e/funcdecl_arg_name.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "returns",
-    "sortText": "70-returns",
+    "sortText": "90-returns",
     "textEdit": {
       "newText": "returns ",
       "range": {

--- a/tests/e2e/funcdecl_arg_name2.json
+++ b/tests/e2e/funcdecl_arg_name2.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "returns",
-    "sortText": "70-returns",
+    "sortText": "90-returns",
     "textEdit": {
       "newText": "returns ",
       "range": {

--- a/tests/e2e/funcdecl_arg_type.json
+++ b/tests/e2e/funcdecl_arg_type.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "List",
-    "sortText": "70-List",
+    "sortText": "90-List",
     "textEdit": {
       "newText": "List[",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "Map",
-    "sortText": "70-Map",
+    "sortText": "90-Map",
     "textEdit": {
       "newText": "Map[",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "any",
-    "sortText": "70-any",
+    "sortText": "90-any",
     "textEdit": {
       "newText": "any ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "boolean",
-    "sortText": "70-boolean",
+    "sortText": "90-boolean",
     "textEdit": {
       "newText": "boolean ",
       "range": {
@@ -89,7 +89,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "float",
-    "sortText": "70-float",
+    "sortText": "90-float",
     "textEdit": {
       "newText": "float ",
       "range": {
@@ -110,7 +110,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "int",
-    "sortText": "70-int",
+    "sortText": "90-int",
     "textEdit": {
       "newText": "int ",
       "range": {
@@ -131,7 +131,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "regex",
-    "sortText": "70-regex",
+    "sortText": "90-regex",
     "textEdit": {
       "newText": "regex ",
       "range": {
@@ -152,7 +152,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "string",
-    "sortText": "70-string",
+    "sortText": "90-string",
     "textEdit": {
       "newText": "string ",
       "range": {
@@ -173,7 +173,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "time",
-    "sortText": "70-time",
+    "sortText": "90-time",
     "textEdit": {
       "newText": "time ",
       "range": {

--- a/tests/e2e/funcdecl_returns.json
+++ b/tests/e2e/funcdecl_returns.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "returns",
-    "sortText": "70-returns",
+    "sortText": "90-returns",
     "textEdit": {
       "newText": "returns ",
       "range": {

--- a/tests/e2e/funcdecl_returns2.json
+++ b/tests/e2e/funcdecl_returns2.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "returns",
-    "sortText": "70-returns",
+    "sortText": "90-returns",
     "textEdit": {
       "newText": "returns ",
       "range": {

--- a/tests/e2e/funcdecl_returns_type.json
+++ b/tests/e2e/funcdecl_returns_type.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "List",
-    "sortText": "70-List",
+    "sortText": "90-List",
     "textEdit": {
       "newText": "List[",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "Map",
-    "sortText": "70-Map",
+    "sortText": "90-Map",
     "textEdit": {
       "newText": "Map[",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "any",
-    "sortText": "70-any",
+    "sortText": "90-any",
     "textEdit": {
       "newText": "any ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "boolean",
-    "sortText": "70-boolean",
+    "sortText": "90-boolean",
     "textEdit": {
       "newText": "boolean ",
       "range": {
@@ -89,7 +89,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "float",
-    "sortText": "70-float",
+    "sortText": "90-float",
     "textEdit": {
       "newText": "float ",
       "range": {
@@ -110,7 +110,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "int",
-    "sortText": "70-int",
+    "sortText": "90-int",
     "textEdit": {
       "newText": "int ",
       "range": {
@@ -131,7 +131,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "regex",
-    "sortText": "70-regex",
+    "sortText": "90-regex",
     "textEdit": {
       "newText": "regex ",
       "range": {
@@ -152,7 +152,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "string",
-    "sortText": "70-string",
+    "sortText": "90-string",
     "textEdit": {
       "newText": "string ",
       "range": {
@@ -173,7 +173,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "time",
-    "sortText": "70-time",
+    "sortText": "90-time",
     "textEdit": {
       "newText": "time ",
       "range": {

--- a/tests/e2e/funcdecl_returns_type_int.json
+++ b/tests/e2e/funcdecl_returns_type_int.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "int",
-    "sortText": "70-int",
+    "sortText": "90-int",
     "textEdit": {
       "newText": "int ",
       "range": {

--- a/tests/e2e/function.json
+++ b/tests/e2e/function.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "function",
-    "sortText": "70-function",
+    "sortText": "90-function",
     "textEdit": {
       "newText": "function ",
       "range": {

--- a/tests/e2e/function_with_args.json
+++ b/tests/e2e/function_with_args.json
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "foreach",
-    "sortText": "70-foreach",
+    "sortText": "90-foreach",
     "textEdit": {
       "newText": "foreach ",
       "range": {

--- a/tests/e2e/http_server_block.json
+++ b/tests/e2e/http_server_block.json
@@ -2,12 +2,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 12,

--- a/tests/e2e/http_server_block.json
+++ b/tests/e2e/http_server_block.json
@@ -10,12 +10,12 @@
       "newText": "as ",
       "range": {
         "end": {
-          "character": 21,
-          "line": 1
+          "character": 12,
+          "line": 0
         },
         "start": {
-          "character": 21,
-          "line": 1
+          "character": 12,
+          "line": 0
         }
       }
     }

--- a/tests/e2e/http_server_block.story
+++ b/tests/e2e/http_server_block.story
@@ -1,0 +1,1 @@
+http server 

--- a/tests/e2e/http_server_block_arg.json
+++ b/tests/e2e/http_server_block_arg.json
@@ -10,12 +10,12 @@
       "newText": "and ",
       "range": {
         "end": {
-          "character": 40,
-          "line": 1
+          "character": 22,
+          "line": 0
         },
         "start": {
-          "character": 40,
-          "line": 1
+          "character": 22,
+          "line": 0
         }
       }
     }
@@ -31,12 +31,12 @@
       "newText": "as ",
       "range": {
         "end": {
-          "character": 40,
-          "line": 1
+          "character": 22,
+          "line": 0
         },
         "start": {
-          "character": 40,
-          "line": 1
+          "character": 22,
+          "line": 0
         }
       }
     }
@@ -52,33 +52,12 @@
       "newText": "or ",
       "range": {
         "end": {
-          "character": 40,
-          "line": 1
+          "character": 22,
+          "line": 0
         },
         "start": {
-          "character": 40,
-          "line": 1
-        }
-      }
-    }
-  },
-  {
-    "detail": "Arg. string",
-    "documentation": "No help available.",
-    "insertTextFormat": 1,
-    "kind": 12,
-    "label": "path",
-    "sortText": "20-path",
-    "textEdit": {
-      "newText": "path:",
-      "range": {
-        "end": {
-          "character": 40,
-          "line": 1
-        },
-        "start": {
-          "character": 40,
-          "line": 1
+          "character": 22,
+          "line": 0
         }
       }
     }
@@ -94,12 +73,12 @@
       "newText": "to ",
       "range": {
         "end": {
-          "character": 40,
-          "line": 1
+          "character": 22,
+          "line": 0
         },
         "start": {
-          "character": 40,
-          "line": 1
+          "character": 22,
+          "line": 0
         }
       }
     }

--- a/tests/e2e/http_server_block_arg.json
+++ b/tests/e2e/http_server_block_arg.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -23,12 +23,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 22,
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/http_server_block_arg.story
+++ b/tests/e2e/http_server_block_arg.story
@@ -1,0 +1,1 @@
+http server path: "/" 

--- a/tests/e2e/if.json
+++ b/tests/e2e/if.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "if",
-    "sortText": "70-if",
+    "sortText": "90-if",
     "textEdit": {
       "newText": "if ",
       "range": {

--- a/tests/e2e/if_expr.json
+++ b/tests/e2e/if_expr.json
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "false",
-    "sortText": "70-false",
+    "sortText": "90-false",
     "textEdit": {
       "newText": "false ",
       "range": {
@@ -119,7 +119,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "not",
-    "sortText": "70-not",
+    "sortText": "90-not",
     "textEdit": {
       "newText": "not ",
       "range": {
@@ -140,7 +140,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "null",
-    "sortText": "70-null",
+    "sortText": "90-null",
     "textEdit": {
       "newText": "null ",
       "range": {
@@ -353,7 +353,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "true",
-    "sortText": "70-true",
+    "sortText": "90-true",
     "textEdit": {
       "newText": "true ",
       "range": {

--- a/tests/e2e/inline_keywords.json
+++ b/tests/e2e/inline_keywords.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/list.json
+++ b/tests/e2e/list.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "List",
-    "sortText": "70-List",
+    "sortText": "90-List",
     "textEdit": {
       "newText": "List[",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "Map",
-    "sortText": "70-Map",
+    "sortText": "90-Map",
     "textEdit": {
       "newText": "Map[",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "any",
-    "sortText": "70-any",
+    "sortText": "90-any",
     "textEdit": {
       "newText": "any ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "boolean",
-    "sortText": "70-boolean",
+    "sortText": "90-boolean",
     "textEdit": {
       "newText": "boolean ",
       "range": {
@@ -89,7 +89,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "float",
-    "sortText": "70-float",
+    "sortText": "90-float",
     "textEdit": {
       "newText": "float ",
       "range": {
@@ -110,7 +110,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "int",
-    "sortText": "70-int",
+    "sortText": "90-int",
     "textEdit": {
       "newText": "int ",
       "range": {
@@ -131,7 +131,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "regex",
-    "sortText": "70-regex",
+    "sortText": "90-regex",
     "textEdit": {
       "newText": "regex ",
       "range": {
@@ -152,7 +152,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "string",
-    "sortText": "70-string",
+    "sortText": "90-string",
     "textEdit": {
       "newText": "string ",
       "range": {
@@ -173,7 +173,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "time",
-    "sortText": "70-time",
+    "sortText": "90-time",
     "textEdit": {
       "newText": "time ",
       "range": {

--- a/tests/e2e/map_key.json
+++ b/tests/e2e/map_key.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "List",
-    "sortText": "70-List",
+    "sortText": "90-List",
     "textEdit": {
       "newText": "List[",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "Map",
-    "sortText": "70-Map",
+    "sortText": "90-Map",
     "textEdit": {
       "newText": "Map[",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "any",
-    "sortText": "70-any",
+    "sortText": "90-any",
     "textEdit": {
       "newText": "any ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "boolean",
-    "sortText": "70-boolean",
+    "sortText": "90-boolean",
     "textEdit": {
       "newText": "boolean ",
       "range": {
@@ -89,7 +89,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "float",
-    "sortText": "70-float",
+    "sortText": "90-float",
     "textEdit": {
       "newText": "float ",
       "range": {
@@ -110,7 +110,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "int",
-    "sortText": "70-int",
+    "sortText": "90-int",
     "textEdit": {
       "newText": "int ",
       "range": {
@@ -131,7 +131,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "regex",
-    "sortText": "70-regex",
+    "sortText": "90-regex",
     "textEdit": {
       "newText": "regex ",
       "range": {
@@ -152,7 +152,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "string",
-    "sortText": "70-string",
+    "sortText": "90-string",
     "textEdit": {
       "newText": "string ",
       "range": {
@@ -173,7 +173,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "time",
-    "sortText": "70-time",
+    "sortText": "90-time",
     "textEdit": {
       "newText": "time ",
       "range": {

--- a/tests/e2e/map_value.json
+++ b/tests/e2e/map_value.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "List",
-    "sortText": "70-List",
+    "sortText": "90-List",
     "textEdit": {
       "newText": "List[",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "Map",
-    "sortText": "70-Map",
+    "sortText": "90-Map",
     "textEdit": {
       "newText": "Map[",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "any",
-    "sortText": "70-any",
+    "sortText": "90-any",
     "textEdit": {
       "newText": "any ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "boolean",
-    "sortText": "70-boolean",
+    "sortText": "90-boolean",
     "textEdit": {
       "newText": "boolean ",
       "range": {
@@ -89,7 +89,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "float",
-    "sortText": "70-float",
+    "sortText": "90-float",
     "textEdit": {
       "newText": "float ",
       "range": {
@@ -110,7 +110,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "int",
-    "sortText": "70-int",
+    "sortText": "90-int",
     "textEdit": {
       "newText": "int ",
       "range": {
@@ -131,7 +131,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "regex",
-    "sortText": "70-regex",
+    "sortText": "90-regex",
     "textEdit": {
       "newText": "regex ",
       "range": {
@@ -152,7 +152,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "string",
-    "sortText": "70-string",
+    "sortText": "90-string",
     "textEdit": {
       "newText": "string ",
       "range": {
@@ -173,7 +173,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "time",
-    "sortText": "70-time",
+    "sortText": "90-time",
     "textEdit": {
       "newText": "time ",
       "range": {

--- a/tests/e2e/nested_service_call4.json
+++ b/tests/e2e/nested_service_call4.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/nested_service_call5.json
+++ b/tests/e2e/nested_service_call5.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/obj_mut_arg2.json
+++ b/tests/e2e/obj_mut_arg2.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/redis-get.json
+++ b/tests/e2e/redis-get.json
@@ -1,0 +1,23 @@
+[
+  {
+    "detail": "Arg. string",
+    "documentation": "No help available.",
+    "insertTextFormat": 1,
+    "kind": 12,
+    "label": "key",
+    "sortText": "20-key",
+    "textEdit": {
+      "newText": "key:",
+      "range": {
+        "end": {
+          "character": 10,
+          "line": 0
+        },
+        "start": {
+          "character": 10,
+          "line": 0
+        }
+      }
+    }
+  }
+]

--- a/tests/e2e/redis-get.story
+++ b/tests/e2e/redis-get.story
@@ -1,0 +1,1 @@
+redis get 

--- a/tests/e2e/redis-get_arg.json
+++ b/tests/e2e/redis-get_arg.json
@@ -10,33 +10,33 @@
       "newText": "and ",
       "range": {
         "end": {
-          "character": 40,
-          "line": 1
+          "character": 17,
+          "line": 0
         },
         "start": {
-          "character": 40,
-          "line": 1
+          "character": 17,
+          "line": 0
         }
       }
     }
   },
   {
-    "detail": "Aliasing",
-    "documentation": "Aliasing",
+    "detail": "Arg. string",
+    "documentation": "No help available.",
     "insertTextFormat": 1,
-    "kind": 14,
-    "label": "as",
-    "sortText": "70-as",
+    "kind": 12,
+    "label": "key",
+    "sortText": "20-key",
     "textEdit": {
-      "newText": "as ",
+      "newText": "key:",
       "range": {
         "end": {
-          "character": 40,
-          "line": 1
+          "character": 17,
+          "line": 0
         },
         "start": {
-          "character": 40,
-          "line": 1
+          "character": 17,
+          "line": 0
         }
       }
     }
@@ -52,33 +52,12 @@
       "newText": "or ",
       "range": {
         "end": {
-          "character": 40,
-          "line": 1
+          "character": 17,
+          "line": 0
         },
         "start": {
-          "character": 40,
-          "line": 1
-        }
-      }
-    }
-  },
-  {
-    "detail": "Arg. string",
-    "documentation": "No help available.",
-    "insertTextFormat": 1,
-    "kind": 12,
-    "label": "path",
-    "sortText": "20-path",
-    "textEdit": {
-      "newText": "path:",
-      "range": {
-        "end": {
-          "character": 40,
-          "line": 1
-        },
-        "start": {
-          "character": 40,
-          "line": 1
+          "character": 17,
+          "line": 0
         }
       }
     }
@@ -94,12 +73,12 @@
       "newText": "to ",
       "range": {
         "end": {
-          "character": 40,
-          "line": 1
+          "character": 17,
+          "line": 0
         },
         "start": {
-          "character": 40,
-          "line": 1
+          "character": 17,
+          "line": 0
         }
       }
     }

--- a/tests/e2e/redis-get_arg.json
+++ b/tests/e2e/redis-get_arg.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/redis-get_arg.story
+++ b/tests/e2e/redis-get_arg.story
@@ -1,0 +1,1 @@
+redis get arg: 2 

--- a/tests/e2e/redis_actions.json
+++ b/tests/e2e/redis_actions.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -341,7 +341,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -446,7 +446,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/redis_get_assignment.json
+++ b/tests/e2e/redis_get_assignment.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/redis_get_assignment.json
+++ b/tests/e2e/redis_get_assignment.json
@@ -10,32 +10,11 @@
       "newText": "and ",
       "range": {
         "end": {
-          "character": 38,
+          "character": 25,
           "line": 0
         },
         "start": {
-          "character": 38,
-          "line": 0
-        }
-      }
-    }
-  },
-  {
-    "detail": "Aliasing",
-    "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
-    "label": "as",
-    "sortText": "70-as",
-    "textEdit": {
-      "newText": "as ",
-      "range": {
-        "end": {
-          "character": 38,
-          "line": 0
-        },
-        "start": {
-          "character": 38,
+          "character": 25,
           "line": 0
         }
       }
@@ -52,32 +31,11 @@
       "newText": "or ",
       "range": {
         "end": {
-          "character": 38,
+          "character": 25,
           "line": 0
         },
         "start": {
-          "character": 38,
-          "line": 0
-        }
-      }
-    }
-  },
-  {
-    "detail": "Arg. string",
-    "documentation": "No help available.",
-    "insertTextFormat": 1,
-    "kind": 12,
-    "label": "path",
-    "sortText": "20-path",
-    "textEdit": {
-      "newText": "path:",
-      "range": {
-        "end": {
-          "character": 38,
-          "line": 0
-        },
-        "start": {
-          "character": 38,
+          "character": 25,
           "line": 0
         }
       }
@@ -94,11 +52,11 @@
       "newText": "to ",
       "range": {
         "end": {
-          "character": 38,
+          "character": 25,
           "line": 0
         },
         "start": {
-          "character": 38,
+          "character": 25,
           "line": 0
         }
       }

--- a/tests/e2e/redis_get_assignment.story
+++ b/tests/e2e/redis_get_assignment.story
@@ -1,0 +1,1 @@
+a = redis get key: "foo" 

--- a/tests/e2e/redis_set_args_2nd.json
+++ b/tests/e2e/redis_set_args_2nd.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/redis_set_args_key.json
+++ b/tests/e2e/redis_set_args_key.json
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "false",
-    "sortText": "70-false",
+    "sortText": "90-false",
     "textEdit": {
       "newText": "false ",
       "range": {
@@ -119,7 +119,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "not",
-    "sortText": "70-not",
+    "sortText": "90-not",
     "textEdit": {
       "newText": "not ",
       "range": {
@@ -140,7 +140,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "null",
-    "sortText": "70-null",
+    "sortText": "90-null",
     "textEdit": {
       "newText": "null ",
       "range": {
@@ -353,7 +353,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "true",
-    "sortText": "70-true",
+    "sortText": "90-true",
     "textEdit": {
       "newText": "true ",
       "range": {

--- a/tests/e2e/redis_string.json
+++ b/tests/e2e/redis_string.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/return.json
+++ b/tests/e2e/return.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "return",
-    "sortText": "70-return",
+    "sortText": "90-return",
     "textEdit": {
       "newText": "return ",
       "range": {

--- a/tests/e2e/return_in_block.json
+++ b/tests/e2e/return_in_block.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "return",
-    "sortText": "70-return",
+    "sortText": "90-return",
     "textEdit": {
       "newText": "return ",
       "range": {

--- a/tests/e2e/runner.py
+++ b/tests/e2e/runner.py
@@ -3,9 +3,12 @@ import io
 import json
 from os import path
 
-from pytest import mark
+from pytest import fixture, mark
 
 from sls import App
+
+import storyscript.hub.Hub as StoryHub
+from storyhub.sdk.AutoUpdateThread import AutoUpdateThread
 
 
 from tests.e2e.utils.features import parse_options
@@ -13,6 +16,12 @@ from tests.e2e.utils.fixtures import find_test_files, hub, test_dir
 
 
 test_files = find_test_files(relative=True)
+
+
+@fixture
+def patched_storyhub(mocker, scope="module"):
+    mocker.patch.object(StoryHub, "StoryscriptHub", return_value=hub)
+    mocker.patch.object(AutoUpdateThread, "dispatch_update")
 
 
 # compile a story and compare its completion with the expected tree
@@ -45,6 +54,7 @@ def run_test(story_path, patch):
     )
 
 
+@mark.usefixtures("patched_storyhub")
 @mark.parametrize("test_file", test_files)
 def test_story(test_file, patch):
     test_file = path.join(test_dir, test_file)

--- a/tests/e2e/service_call_parens.json
+++ b/tests/e2e/service_call_parens.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/service_call_parens2.json
+++ b/tests/e2e/service_call_parens2.json
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "false",
-    "sortText": "70-false",
+    "sortText": "90-false",
     "textEdit": {
       "newText": "false ",
       "range": {
@@ -119,7 +119,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "not",
-    "sortText": "70-not",
+    "sortText": "90-not",
     "textEdit": {
       "newText": "not ",
       "range": {
@@ -140,7 +140,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "null",
-    "sortText": "70-null",
+    "sortText": "90-null",
     "textEdit": {
       "newText": "null ",
       "range": {
@@ -353,7 +353,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "true",
-    "sortText": "70-true",
+    "sortText": "90-true",
     "textEdit": {
       "newText": "true ",
       "range": {

--- a/tests/e2e/service_data_var.json
+++ b/tests/e2e/service_data_var.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/service_minus.json
+++ b/tests/e2e/service_minus.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/slack_actions.json
+++ b/tests/e2e/slack_actions.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -89,7 +89,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -131,7 +131,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/story_nl.json
+++ b/tests/e2e/story_nl.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/str_contains.json
+++ b/tests/e2e/str_contains.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/str_substring_both.json
+++ b/tests/e2e/str_substring_both.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -89,7 +89,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/str_substring_end.json
+++ b/tests/e2e/str_substring_end.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/str_substring_start.json
+++ b/tests/e2e/str_substring_start.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/string_mut_arg2.json
+++ b/tests/e2e/string_mut_arg2.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/string_mut_arg3.json
+++ b/tests/e2e/string_mut_arg3.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/string_mut_nested.json
+++ b/tests/e2e/string_mut_nested.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/throw.json
+++ b/tests/e2e/throw.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "throw",
-    "sortText": "70-throw",
+    "sortText": "90-throw",
     "textEdit": {
       "newText": "throw ",
       "range": {

--- a/tests/e2e/throw_in_block.json
+++ b/tests/e2e/throw_in_block.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "throw",
-    "sortText": "70-throw",
+    "sortText": "90-throw",
     "textEdit": {
       "newText": "throw ",
       "range": {

--- a/tests/e2e/to_type.json
+++ b/tests/e2e/to_type.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "List",
-    "sortText": "70-List",
+    "sortText": "90-List",
     "textEdit": {
       "newText": "List[",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "Map",
-    "sortText": "70-Map",
+    "sortText": "90-Map",
     "textEdit": {
       "newText": "Map[",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "any",
-    "sortText": "70-any",
+    "sortText": "90-any",
     "textEdit": {
       "newText": "any ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "boolean",
-    "sortText": "70-boolean",
+    "sortText": "90-boolean",
     "textEdit": {
       "newText": "boolean ",
       "range": {
@@ -89,7 +89,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "float",
-    "sortText": "70-float",
+    "sortText": "90-float",
     "textEdit": {
       "newText": "float ",
       "range": {
@@ -110,7 +110,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "int",
-    "sortText": "70-int",
+    "sortText": "90-int",
     "textEdit": {
       "newText": "int ",
       "range": {
@@ -131,7 +131,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "regex",
-    "sortText": "70-regex",
+    "sortText": "90-regex",
     "textEdit": {
       "newText": "regex ",
       "range": {
@@ -152,7 +152,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "string",
-    "sortText": "70-string",
+    "sortText": "90-string",
     "textEdit": {
       "newText": "string ",
       "range": {
@@ -173,7 +173,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "time",
-    "sortText": "70-time",
+    "sortText": "90-time",
     "textEdit": {
       "newText": "time ",
       "range": {

--- a/tests/e2e/to_type_list.json
+++ b/tests/e2e/to_type_list.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "List",
-    "sortText": "70-List",
+    "sortText": "90-List",
     "textEdit": {
       "newText": "List[",
       "range": {

--- a/tests/e2e/to_type_map.json
+++ b/tests/e2e/to_type_map.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "Map",
-    "sortText": "70-Map",
+    "sortText": "90-Map",
     "textEdit": {
       "newText": "Map[",
       "range": {

--- a/tests/e2e/try.json
+++ b/tests/e2e/try.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "true",
-    "sortText": "70-true",
+    "sortText": "90-true",
     "textEdit": {
       "newText": "true ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "try",
-    "sortText": "70-try",
+    "sortText": "90-try",
     "textEdit": {
       "newText": "try ",
       "range": {

--- a/tests/e2e/unknown_service.json
+++ b/tests/e2e/unknown_service.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/uuid_commands.json
+++ b/tests/e2e/uuid_commands.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/when.json
+++ b/tests/e2e/when.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "when",
-    "sortText": "70-when",
+    "sortText": "90-when",
     "textEdit": {
       "newText": "when ",
       "range": {

--- a/tests/e2e/when_concise_args.json
+++ b/tests/e2e/when_concise_args.json
@@ -2,12 +2,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 24,

--- a/tests/e2e/when_concise_args.json
+++ b/tests/e2e/when_concise_args.json
@@ -1,5 +1,26 @@
 [
   {
+    "detail": "Aliasing",
+    "documentation": "Aliasing",
+    "insertTextFormat": 1,
+    "kind": 14,
+    "label": "as",
+    "sortText": "70-as",
+    "textEdit": {
+      "newText": "as ",
+      "range": {
+        "end": {
+          "character": 24,
+          "line": 0
+        },
+        "start": {
+          "character": 24,
+          "line": 0
+        }
+      }
+    }
+  },
+  {
     "detail": "Arg. enum",
     "documentation": "No help available.",
     "insertTextFormat": 1,

--- a/tests/e2e/when_concise_args2.json
+++ b/tests/e2e/when_concise_args2.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -23,12 +23,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 38,
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -89,7 +89,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/when_concise_args3.json
+++ b/tests/e2e/when_concise_args3.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -23,12 +23,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 47,
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/when_concise_args3.json
+++ b/tests/e2e/when_concise_args3.json
@@ -21,6 +21,27 @@
     }
   },
   {
+    "detail": "Aliasing",
+    "documentation": "Aliasing",
+    "insertTextFormat": 1,
+    "kind": 14,
+    "label": "as",
+    "sortText": "70-as",
+    "textEdit": {
+      "newText": "as ",
+      "range": {
+        "end": {
+          "character": 47,
+          "line": 0
+        },
+        "start": {
+          "character": 44,
+          "line": 0
+        }
+      }
+    }
+  },
+  {
     "detail": "Logical disjunction",
     "documentation": "Logical disjunction",
     "insertTextFormat": 1,

--- a/tests/e2e/when_concise_events.json
+++ b/tests/e2e/when_concise_events.json
@@ -1,5 +1,26 @@
 [
   {
+    "detail": "Aliasing",
+    "documentation": "Aliasing",
+    "insertTextFormat": 1,
+    "kind": 14,
+    "label": "as",
+    "sortText": "70-as",
+    "textEdit": {
+      "newText": "as ",
+      "range": {
+        "end": {
+          "character": 17,
+          "line": 0
+        },
+        "start": {
+          "character": 17,
+          "line": 0
+        }
+      }
+    }
+  },
+  {
     "detail": "Event: Listen and respond to http connections by",
     "documentation": "Listen and respond to http connections by\nregistering with the Storyscript Gateway resulting in a serverless function.\n",
     "insertTextFormat": 2,

--- a/tests/e2e/when_concise_events.json
+++ b/tests/e2e/when_concise_events.json
@@ -2,12 +2,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 17,

--- a/tests/e2e/when_http_command_event_invalid.json
+++ b/tests/e2e/when_http_command_event_invalid.json
@@ -2,12 +2,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 18,

--- a/tests/e2e/when_http_command_event_invalid.json
+++ b/tests/e2e/when_http_command_event_invalid.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "detail": "Aliasing",
+    "documentation": "Aliasing",
+    "insertTextFormat": 1,
+    "kind": 14,
+    "label": "as",
+    "sortText": "70-as",
+    "textEdit": {
+      "newText": "as ",
+      "range": {
+        "end": {
+          "character": 18,
+          "line": 0
+        },
+        "start": {
+          "character": 18,
+          "line": 0
+        }
+      }
+    }
+  }
+]

--- a/tests/e2e/when_http_command_event_invalid2.json
+++ b/tests/e2e/when_http_command_event_invalid2.json
@@ -2,12 +2,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 18,

--- a/tests/e2e/when_http_command_event_invalid2.json
+++ b/tests/e2e/when_http_command_event_invalid2.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "detail": "Aliasing",
+    "documentation": "Aliasing",
+    "insertTextFormat": 1,
+    "kind": 14,
+    "label": "as",
+    "sortText": "70-as",
+    "textEdit": {
+      "newText": "as ",
+      "range": {
+        "end": {
+          "character": 18,
+          "line": 0
+        },
+        "start": {
+          "character": 18,
+          "line": 0
+        }
+      }
+    }
+  }
+]

--- a/tests/e2e/when_http_data_var2.json
+++ b/tests/e2e/when_http_data_var2.json
@@ -2,12 +2,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 14,

--- a/tests/e2e/when_http_data_var2.json
+++ b/tests/e2e/when_http_data_var2.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "detail": "Aliasing",
+    "documentation": "Aliasing",
+    "insertTextFormat": 1,
+    "kind": 14,
+    "label": "as",
+    "sortText": "70-as",
+    "textEdit": {
+      "newText": "as ",
+      "range": {
+        "end": {
+          "character": 14,
+          "line": 1
+        },
+        "start": {
+          "character": 14,
+          "line": 1
+        }
+      }
+    }
+  }
+]

--- a/tests/e2e/when_http_data_var3.json
+++ b/tests/e2e/when_http_data_var3.json
@@ -2,12 +2,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 21,

--- a/tests/e2e/when_http_data_var4.json
+++ b/tests/e2e/when_http_data_var4.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -23,12 +23,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 27,
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/when_http_data_var4.json
+++ b/tests/e2e/when_http_data_var4.json
@@ -21,6 +21,27 @@
     }
   },
   {
+    "detail": "Aliasing",
+    "documentation": "Aliasing",
+    "insertTextFormat": 1,
+    "kind": 14,
+    "label": "as",
+    "sortText": "70-as",
+    "textEdit": {
+      "newText": "as ",
+      "range": {
+        "end": {
+          "character": 27,
+          "line": 1
+        },
+        "start": {
+          "character": 27,
+          "line": 1
+        }
+      }
+    }
+  },
+  {
     "detail": "Logical disjunction",
     "documentation": "Logical disjunction",
     "insertTextFormat": 1,

--- a/tests/e2e/when_http_invalid_var2.json
+++ b/tests/e2e/when_http_invalid_var2.json
@@ -2,12 +2,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 14,

--- a/tests/e2e/when_http_invalid_var2.json
+++ b/tests/e2e/when_http_invalid_var2.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "detail": "Aliasing",
+    "documentation": "Aliasing",
+    "insertTextFormat": 1,
+    "kind": 14,
+    "label": "as",
+    "sortText": "70-as",
+    "textEdit": {
+      "newText": "as ",
+      "range": {
+        "end": {
+          "character": 14,
+          "line": 1
+        },
+        "start": {
+          "character": 14,
+          "line": 1
+        }
+      }
+    }
+  }
+]

--- a/tests/e2e/when_http_invalid_var3.json
+++ b/tests/e2e/when_http_invalid_var3.json
@@ -2,12 +2,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 14,

--- a/tests/e2e/when_http_invalid_var3.json
+++ b/tests/e2e/when_http_invalid_var3.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "detail": "Aliasing",
+    "documentation": "Aliasing",
+    "insertTextFormat": 1,
+    "kind": 14,
+    "label": "as",
+    "sortText": "70-as",
+    "textEdit": {
+      "newText": "as ",
+      "range": {
+        "end": {
+          "character": 14,
+          "line": 1
+        },
+        "start": {
+          "character": 14,
+          "line": 1
+        }
+      }
+    }
+  }
+]

--- a/tests/e2e/when_http_object_args.json
+++ b/tests/e2e/when_http_object_args.json
@@ -2,12 +2,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 20,

--- a/tests/e2e/when_http_object_args.json
+++ b/tests/e2e/when_http_object_args.json
@@ -1,5 +1,26 @@
 [
   {
+    "detail": "Aliasing",
+    "documentation": "Aliasing",
+    "insertTextFormat": 1,
+    "kind": 14,
+    "label": "as",
+    "sortText": "70-as",
+    "textEdit": {
+      "newText": "as ",
+      "range": {
+        "end": {
+          "character": 20,
+          "line": 1
+        },
+        "start": {
+          "character": 20,
+          "line": 1
+        }
+      }
+    }
+  },
+  {
     "detail": "Arg. enum",
     "documentation": "No help available.",
     "insertTextFormat": 1,

--- a/tests/e2e/when_http_object_args2.json
+++ b/tests/e2e/when_http_object_args2.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/when_http_object_args3.json
+++ b/tests/e2e/when_http_object_args3.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -23,12 +23,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 40,
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -89,7 +89,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/when_http_object_args4.json
+++ b/tests/e2e/when_http_object_args4.json
@@ -21,6 +21,27 @@
     }
   },
   {
+    "detail": "Aliasing",
+    "documentation": "Aliasing",
+    "insertTextFormat": 1,
+    "kind": 14,
+    "label": "as",
+    "sortText": "70-as",
+    "textEdit": {
+      "newText": "as ",
+      "range": {
+        "end": {
+          "character": 44,
+          "line": 1
+        },
+        "start": {
+          "character": 44,
+          "line": 1
+        }
+      }
+    }
+  },
+  {
     "detail": "Logical disjunction",
     "documentation": "Logical disjunction",
     "insertTextFormat": 1,

--- a/tests/e2e/when_http_object_args4.json
+++ b/tests/e2e/when_http_object_args4.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -23,12 +23,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 44,
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/when_req_actions.json
+++ b/tests/e2e/when_req_actions.json
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -89,7 +89,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -194,7 +194,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/when_req_actions_args2.json
+++ b/tests/e2e/when_req_actions_args2.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/when_undefined.json
+++ b/tests/e2e/when_undefined.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "detail": "Aliasing",
+    "documentation": "Aliasing",
+    "insertTextFormat": 1,
+    "kind": 14,
+    "label": "as",
+    "sortText": "70-as",
+    "textEdit": {
+      "newText": "as ",
+      "range": {
+        "end": {
+          "character": 14,
+          "line": 0
+        },
+        "start": {
+          "character": 14,
+          "line": 0
+        }
+      }
+    }
+  }
+]

--- a/tests/e2e/when_undefined.json
+++ b/tests/e2e/when_undefined.json
@@ -2,12 +2,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 14,

--- a/tests/e2e/when_undefined2.json
+++ b/tests/e2e/when_undefined2.json
@@ -1,1 +1,23 @@
-[]
+[
+  {
+    "detail": "Aliasing",
+    "documentation": "Aliasing",
+    "insertTextFormat": 1,
+    "kind": 14,
+    "label": "as",
+    "sortText": "70-as",
+    "textEdit": {
+      "newText": "as ",
+      "range": {
+        "end": {
+          "character": 21,
+          "line": 0
+        },
+        "start": {
+          "character": 21,
+          "line": 0
+        }
+      }
+    }
+  }
+]

--- a/tests/e2e/when_undefined2.json
+++ b/tests/e2e/when_undefined2.json
@@ -2,12 +2,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 21,

--- a/tests/e2e/when_undefined3.json
+++ b/tests/e2e/when_undefined3.json
@@ -21,6 +21,27 @@
     }
   },
   {
+    "detail": "Aliasing",
+    "documentation": "Aliasing",
+    "insertTextFormat": 1,
+    "kind": 14,
+    "label": "as",
+    "sortText": "70-as",
+    "textEdit": {
+      "newText": "as ",
+      "range": {
+        "end": {
+          "character": 27,
+          "line": 0
+        },
+        "start": {
+          "character": 27,
+          "line": 0
+        }
+      }
+    }
+  },
+  {
     "detail": "Logical disjunction",
     "documentation": "Logical disjunction",
     "insertTextFormat": 1,

--- a/tests/e2e/when_undefined3.json
+++ b/tests/e2e/when_undefined3.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -23,12 +23,12 @@
   {
     "detail": "Aliasing",
     "documentation": "Aliasing",
-    "insertTextFormat": 1,
-    "kind": 14,
+    "insertTextFormat": 2,
+    "kind": 15,
     "label": "as",
     "sortText": "70-as",
     "textEdit": {
-      "newText": "as ",
+      "newText": "as ${1:<name>}",
       "range": {
         "end": {
           "character": 27,
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -68,7 +68,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/when_undefined7.json
+++ b/tests/e2e/when_undefined7.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/when_undefined8.json
+++ b/tests/e2e/when_undefined8.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "and",
-    "sortText": "70-and",
+    "sortText": "90-and",
     "textEdit": {
       "newText": "and ",
       "range": {
@@ -26,7 +26,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "or",
-    "sortText": "70-or",
+    "sortText": "90-or",
     "textEdit": {
       "newText": "or ",
       "range": {
@@ -47,7 +47,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "to",
-    "sortText": "70-to",
+    "sortText": "90-to",
     "textEdit": {
       "newText": "to ",
       "range": {

--- a/tests/e2e/while.json
+++ b/tests/e2e/while.json
@@ -5,7 +5,7 @@
     "insertTextFormat": 1,
     "kind": 14,
     "label": "while",
-    "sortText": "70-while",
+    "sortText": "90-while",
     "textEdit": {
       "newText": "while ",
       "range": {

--- a/tests/unittests/parser/parso.py
+++ b/tests/unittests/parser/parso.py
@@ -101,7 +101,7 @@ def test_parser_service():
 
 def test_parser_service_args():
     s = parse("foo bar")
-    compare(s, op() + [StoryTokenSpace.NAME])
+    compare(s, op() + [StoryTokenSpace.NAME, StoryTokenSpace.AS])
 
 
 def test_parser_service_value():
@@ -111,7 +111,7 @@ def test_parser_service_value():
 
 def test_parser_service_end():
     s = parse("foo bar a:1")
-    compare(s, op() + [StoryTokenSpace.NAME])
+    compare(s, op() + [StoryTokenSpace.NAME, StoryTokenSpace.AS])
 
 
 def test_parser_if_expr():
@@ -122,3 +122,8 @@ def test_parser_if_expr():
 def test_parser_if_block():
     s = parse("if a\n")
     compare(s, [StoryTokenSpace.INDENT])
+
+
+def test_parser_foreach_as():
+    s = parse("foreach foo as ")
+    compare(s, [StoryTokenSpace.NAME])


### PR DESCRIPTION
Allows `as` completion for `when` and service blocks.

Fixes https://github.com/storyscript/sls/issues/184
Preps for https://github.com/storyscript/sls/issues/172