### PR TITLE
Fix Storyscript Hub to SLS's workspace registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM            python:3.7-alpine
 
 ENV             SENTRY_DSN https://bcd976c210e8458ab717fdea741c6a5a@sentry.io/1822749
+ENV             STORYSCRIPT_HUB_API https://api.storyscript.io/graphql
 
 RUN             mkdir /app
 WORKDIR         /app

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ classifiers = [
 
 requirements = [
     "python-jsonrpc-server==0.1.2",
-    "storyscript==0.26.0",
+    "storyscript==0.26.1",
     "click~=7.0",
     "click-aliases~=1.0",
     "cachetools~=3.1",

--- a/sls/completion/cache.py
+++ b/sls/completion/cache.py
@@ -13,9 +13,9 @@ class ContextCache:
         - SymbolTable (global)
     """
 
-    def __init__(self):
-        self.global_ = GlobalScopeCache()
-        self.current = CurrentScopeCache(self.global_)
+    def __init__(self, hub):
+        self.global_ = GlobalScopeCache(story_hub=hub)
+        self.current = CurrentScopeCache(self.global_, hub=hub)
 
     def update(self, context):
         self.global_.update(context)

--- a/sls/completion/complete.py
+++ b/sls/completion/complete.py
@@ -58,7 +58,7 @@ class Completion:
 
     @classmethod
     def full(cls, service_registry):
-        context_cache = ContextCache()
+        context_cache = ContextCache(service_registry.hub)
         return cls(
             context_cache=context_cache,
             plugins=[ASTAnalyzer(service_registry, context_cache),],

--- a/sls/completion/scope/current.py
+++ b/sls/completion/scope/current.py
@@ -42,10 +42,11 @@ class CurrentScopeCache:
     Cache for the current scope
     """
 
-    def __init__(self, global_):
+    def __init__(self, global_, hub):
         self.global_ = global_
         self.scope_cache = LRUCache(100)
         self.current_scope = None
+        self.hub = hub
 
     def update(self, context):
         self.current_scope = self.build_current_scope(context)
@@ -84,7 +85,7 @@ class CurrentScopeCache:
         ws = " " * (len(block[-1]) - len(block[-1].lstrip()))
         text += f"\n{ws}{CACHE_DUMMY_VAR} = 0"
         scope = self.global_.global_scope.copy()
-        output = loads(text, backend="semantic", scope=scope)
+        output = loads(text, backend="semantic", scope=scope, hub=self.hub)
         if output.success():
             tree = output.result().output()
             return scope_finder(tree, CACHE_DUMMY_VAR)

--- a/sls/completion/scope/global_.py
+++ b/sls/completion/scope/global_.py
@@ -18,11 +18,11 @@ log = logger(__name__)
 CacheOutput = namedtuple("CacheOutput", ["function_table", "root_scope"])
 
 
-def cache_compile(text):
+def cache_compile(text, story_hub):
     """
     Compile text and return CacheOutput on success.
     """
-    output = loads(text, backend="semantic")
+    output = loads(text, backend="semantic", hub=story_hub)
     if output.success():
         module = output.result().module()
         return CacheOutput(
@@ -37,11 +37,12 @@ class GlobalScopeCache:
         - SymbolTable
     """
 
-    def __init__(self):
+    def __init__(self, story_hub):
         self.function_table = None
         self.mutation_table = hub.mutations()
         self.global_scope = None
         self.block_cache = LRUCache(1000)
+        self.story_hub = story_hub
 
     def update(self, context):
         self.global_scope = self.aggregate_scope_blocks(context)
@@ -58,7 +59,7 @@ class GlobalScopeCache:
             if story_text in self.block_cache:
                 result = self.block_cache[story_text]
             else:
-                result = cache_compile(story_text)
+                result = cache_compile(story_text, self.story_hub)
                 self.block_cache[story_text] = result
 
             if result is not None:

--- a/sls/services/hub.py
+++ b/sls/services/hub.py
@@ -1,10 +1,19 @@
-from storyhub.sdk.StoryscriptHub import StoryscriptHub
+from os import makedirs, path
+
+from storyhub.sdk.AutoUpdateThread import AutoUpdateThread
+from storyhub.sdk.ServiceWrapper import ServiceWrapper
+
+import appdirs
 
 from sls.services.service import Service
 
 from ..logging import logger
 
 log = logger(__name__)
+
+
+def get_cache_dir():
+    return appdirs.user_cache_dir("storyscript", "sls")
 
 
 class ServiceHub:
@@ -14,9 +23,28 @@ class ServiceHub:
 
     def __init__(self, hub=None):
         if hub is None:
-            self.hub = StoryscriptHub()
+            cache_dir = get_cache_dir()
+            self.hub_path = path.join(cache_dir, "hub.json")
+            if path.exists(self.hub_path):
+                self.hub = ServiceWrapper.from_json_file(self.hub_path)
+            else:
+                makedirs(cache_dir, exist_ok=True)
+                self.hub = ServiceWrapper()
+                self.update_service_wrapper()
+            self.update_thread = AutoUpdateThread(
+                self.update_service_wrapper, initial_update=False
+            )
         else:
             self.hub = hub
+
+    def update_service_wrapper(self):
+        """
+        Update the in-memory ServiceWrapper and save a snapshot into
+        the cache_dir.
+        """
+        services = self.hub.fetch_services()
+        self.hub.reload_services(services)
+        self.hub.as_json_file(self.hub_path)
 
     def find_services(self, keyword):
         for service_name in self.hub.get_all_service_names():

--- a/tests/integration/app.py
+++ b/tests/integration/app.py
@@ -26,7 +26,7 @@ def test_complete(hub):
     """
     Tests that an SLS App can perform completion.
     """
-    app = App()
+    app = App(hub=hub)
     result = app.complete(".uri.", "h")
     del result[0]["documentation"]
     del result[0]["detail"]
@@ -49,7 +49,7 @@ def test_complete_with_line(hub):
     """
     Tests that an SLS App can perform completion.
     """
-    app = App()
+    app = App(hub=hub)
     result = app.complete(".uri.", "foobar\nh", line=1)
     del result[0]["documentation"]
     del result[0]["detail"]
@@ -72,7 +72,7 @@ def test_complete_with_line_column(hub):
     """
     Tests that an SLS App can perform completion.
     """
-    app = App()
+    app = App(hub=hub)
     result = app.complete(".uri.", "foobar\nhttp foo", line=1, column=1)
     del result[0]["documentation"]
     del result[0]["detail"]

--- a/tests/integration/completion/basic.py
+++ b/tests/integration/completion/basic.py
@@ -4,6 +4,9 @@ from sls.completion.complete import Completion
 from sls.document import Document, Position
 from sls.services.hub import ServiceHub
 
+from tests.e2e.utils.fixtures import hub
+
+
 int_mutations = [
     "absolute",
     "decrement",
@@ -20,7 +23,7 @@ def document(text):
 
 class CompletionTest:
     def __init__(self):
-        self.c = Completion.full(ServiceHub())
+        self.c = Completion.full(ServiceHub(hub))
 
     def set(self, text):
         self.doc = document(text)
@@ -36,7 +39,7 @@ class CompletionTest:
 
 
 @fixture
-def completion(hub):
+def completion():
     return CompletionTest()
 
 

--- a/tests/integration/completion/cache.py
+++ b/tests/integration/completion/cache.py
@@ -4,12 +4,14 @@ from sls.completion.cache import ContextCache
 from sls.completion.context import CompletionContext
 from sls.document import Document, Position
 
+from tests.e2e.utils.fixtures import hub
+
 
 def build_cache(text, line):
     doc = Document(uri=".text.", text=text)
     pos = Position(line, 0)
     context = CompletionContext(ws=None, doc=doc, pos=pos)
-    cache = ContextCache()
+    cache = ContextCache(hub=hub)
     cache.update(context)
     return cache
 

--- a/tests/integration/completion/scope/current.py
+++ b/tests/integration/completion/scope/current.py
@@ -4,13 +4,15 @@ from sls.document import Document, Position
 
 from storyscript.compiler.semantics.symbols.Scope import Scope
 
+from tests.e2e.utils.fixtures import hub
+
 
 def test_error(magic):
     doc = Document(uri=".text.", text="a = $\n  b = \n")
     pos = Position(1, 4)
     context = CompletionContext(ws=magic(), doc=doc, pos=pos)
     global_ = magic()
-    current = CurrentScopeCache(global_=global_)
+    current = CurrentScopeCache(global_=global_, hub=hub)
     current.update(context)
     symbols = [s.name() for s in current.current_scope.symbols()]
     assert symbols == []
@@ -22,7 +24,7 @@ def test_caching(magic):
     context = CompletionContext(ws=magic(), doc=doc, pos=pos)
     global_ = magic()
     global_.global_scope = Scope.root()
-    current = CurrentScopeCache(global_=global_)
+    current = CurrentScopeCache(global_=global_, hub=hub)
     current.update(context)
     symbols = [s.name() for s in current.current_scope.symbols()]
     assert symbols == ["app"]
@@ -39,7 +41,7 @@ def test_complete(magic):
     context = CompletionContext(ws=magic(), doc=doc, pos=pos)
     global_ = magic()
     global_.global_scope = Scope.root()
-    current = CurrentScopeCache(global_=global_)
+    current = CurrentScopeCache(global_=global_, hub=hub)
     current.update(context)
     assert [x.symbol.name() for x in current.complete("a")] == ["app"]
     assert [x.symbol.name() for x in current.complete("b")] == []

--- a/tests/integration/completion/scope/global.py
+++ b/tests/integration/completion/scope/global.py
@@ -4,12 +4,14 @@ from sls.document import Document, Position
 
 from storyscript.compiler.semantics.symbols.Scope import Scope
 
+from tests.e2e.utils.fixtures import hub
+
 
 def test_error(magic):
     doc = Document(uri=".text.", text="a = $\n  b = \n")
     pos = Position(1, 4)
     context = CompletionContext(ws=magic(), doc=doc, pos=pos)
-    glob = GlobalScopeCache()
+    glob = GlobalScopeCache(story_hub=hub)
     glob.update(context)
     fns = [*glob.function_table.functions.keys()]
     assert fns == []
@@ -21,7 +23,7 @@ def test_caching(magic):
     context = CompletionContext(ws=magic(), doc=doc, pos=pos)
     global_ = magic()
     global_.global_scope = Scope.root()
-    glob = GlobalScopeCache()
+    glob = GlobalScopeCache(story_hub=hub)
     glob.update(context)
     fns = [*glob.function_table.functions.keys()]
     assert fns == ["foo"]
@@ -33,7 +35,7 @@ def test_complete(magic):
     context = CompletionContext(ws=magic(), doc=doc, pos=pos)
     global_ = magic()
     global_.global_scope = Scope.root()
-    glob = GlobalScopeCache()
+    glob = GlobalScopeCache(story_hub=hub)
     glob.update(context)
     assert [x.function.name() for x in glob.complete("f")] == ["foo"]
     assert [x.function.name() for x in glob.complete("b")] == []

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,33 +1,8 @@
-from os import path
-
 from pytest import fixture
 
-from storyhub.sdk.ServiceWrapper import ServiceWrapper
 from storyhub.sdk.StoryscriptHub import StoryscriptHub
 
-
-def singleton(fn):
-    """
-    Lazily instantiate a function
-    """
-    _instance = None
-
-    def wrapped():
-        nonlocal _instance
-        if _instance is None:
-            _instance = fn()
-        return _instance
-
-    return wrapped
-
-
-@singleton
-def load():
-    script_dir = path.dirname(path.realpath(__file__))
-    fixture_dir = path.join(script_dir, "..", "fixtures", "hub")
-    fixture_file = path.join(fixture_dir, "hub.fixed.json")
-
-    return ServiceWrapper.from_json_file(fixture_file)
+from tests.e2e.utils.fixtures import hub as story_hub
 
 
 @fixture
@@ -35,8 +10,8 @@ def hub(patch):
     patch.many(
         StoryscriptHub, ["update_cache", "get_all_service_names", "get"]
     )
-    consthub = load()
-    StoryscriptHub.get.side_effect = consthub.get
+    StoryscriptHub.get.side_effect = story_hub.get
     StoryscriptHub.get_all_service_names.side_effect = (
-        consthub.get_all_service_names
+        story_hub.get_all_service_names
     )
+    return story_hub

--- a/tests/integration/services/hub.py
+++ b/tests/integration/services/hub.py
@@ -1,0 +1,60 @@
+import json
+
+from pytest import fixture
+
+from sls.services.hub import ServiceHub
+import sls.services.hub as HubModule
+
+from storyhub.sdk.AutoUpdateThread import AutoUpdateThread
+from storyhub.sdk.ServiceWrapper import ServiceWrapper
+
+
+@fixture
+def no_updates(patch):
+    patch.init(AutoUpdateThread)
+
+
+@fixture
+def cache_dir(patch, tmpdir):
+    patch.object(HubModule, "get_cache_dir", return_value=tmpdir)
+    return tmpdir
+
+
+def test_hub_create_json(patch, cache_dir, no_updates):
+    patch.object(ServiceWrapper, "fetch_services", return_value=[])
+    hub_path = cache_dir.join("hub.json")
+    hub = ServiceHub()
+    assert hub.hub_path == hub_path
+    assert hub_path.read() == "[]"
+    AutoUpdateThread.__init__.assert_called()
+
+
+def test_hub_get_existing_json(patch, cache_dir, no_updates):
+    patch.object(ServiceWrapper, "fetch_services")
+    patch.object(ServiceHub, "update_service_wrapper")
+    service = {
+        "service": {
+            "name": "foo",
+            "alias": None,
+            "owner": {"username": "baruser"},
+        }
+    }
+    cache_dir.join("hub.json").write(f"[{json.dumps(service)}]")
+    ServiceHub()
+    ServiceWrapper.fetch_services.assert_not_called()
+    ServiceHub.update_service_wrapper.assert_not_called()
+    AutoUpdateThread.__init__.assert_called()
+
+
+def test_hub_create_dir(patch, tmpdir, no_updates):
+    """
+    Ensures that ServiceHub creates missing directories.
+    """
+    cache_dir = tmpdir.join("extra_dir")
+    patch.object(HubModule, "get_cache_dir", return_value=cache_dir)
+    patch.object(ServiceWrapper, "fetch_services", return_value=[])
+    hub_path = cache_dir.join("hub.json")
+    hub = ServiceHub()
+    assert hub.hub_path == hub_path
+    assert hub_path.read() == "[]"
+    AutoUpdateThread.__init__.assert_called()

--- a/tests/unittests/services/hub.py
+++ b/tests/unittests/services/hub.py
@@ -1,4 +1,6 @@
-from sls.services.hub import ServiceHub
+import appdirs
+
+from sls.services.hub import get_cache_dir, ServiceHub
 
 
 def test_find_services_invalid_service(magic, patch):
@@ -14,3 +16,8 @@ def test_find_services_invalid_service(magic, patch):
     assert ServiceHub.get_service_data.call_count == 2
     assert len(services) == 1
     assert services[0].name() == "srv2"
+
+
+def test_cache_dir(patch):
+    patch.object(appdirs, "user_cache_dir", return_value="<cache-dir>")
+    assert get_cache_dir() == "<cache-dir>"


### PR DESCRIPTION
Fixes storyscript/sls#182 and storyscript/sls#186

With this PR SLS will only use the more modern `ServiceWrapper` from the SDK which keeps all services in memory. This should make responses a lot faster as no database file nor GraphQL request should be made.